### PR TITLE
CSRF mitigation for hardened state

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,6 +51,8 @@ app.secret_key = "secret123"
 # Hardening feature flag
 harden = False
 
+app.config["HARDENED"] = harden
+
 # Rate limiting configuration
 RATE_LIMIT_WINDOW = 3 * 60 * 60  # 3 hours in seconds
 UNAUTHENTICATED_LIMIT = 5  # requests per IP per window
@@ -984,6 +986,8 @@ def create_admin(current_user):
 def harden_toggle():
     global harden
     harden = not harden
+
+    app.config["HARDENED"] = harden
 
     return jsonify({
         'status': 'success',


### PR DESCRIPTION
Implemented functionality for CSRF attacks involving unsafe requests so they require an Authorization header token. Integrated with the vulnerability toggle button on the home page. 

Quick testing guide (will expand on this and include it in the documentation in the next PR):
1) While running Docker, using the UI, create a test account on the main page, confirm it is created by logging in, and then log out
2) On the main page, toggle vulnerabilities button and ensure that hardened state is on
3) Log in with admin account (admin/admin123)
4) In the admin tab, find the list of accounts created in the database, which should include user's created test account. Identify the User ID (leftmost column).
5) Create an HTML file that auto-submits a POST form to http://localhost:5000/admin/delete_account/<user_id>, using the correct User ID. Open this file using the same browser the app is running on, and while still logged in as admin.
6) If successful, the action should be blocked, and an error message should appear. 
7) Log out, refresh, toggle vulnerabilities button so hardened state is off, and repeat steps 3-6. If successful, a success message will appear, and the associated user account will be deleted.