### PR TITLE
Token session expiration hardened

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 import platform
 from mitigations import BOLA
 from mitigations import sql_injections
+from mitigations import session_exp
 
 # Load environment variables
 load_dotenv()

--- a/mitigations/session_exp.py
+++ b/mitigations/session_exp.py
@@ -1,13 +1,11 @@
 from datetime import datetime, timedelta
 
+
 def generate_token_hardened(user_id, username, is_admin):
     return {
         'user_id': user_id,
         'username': username,
         'is_admin': is_admin,
         'iat': datetime.utcnow(),
-        'exp': datetime.utcnow() + timedelta(minutes=15)
+        'exp': datetime.utcnow() + timedelta(minutes=1)
     }
-
-#def verify_token_hardened():
-#    return jwt.decode(token, JWT_SECRET, algorithms=ALGORITHMS, options={"verify_exp": True})

--- a/mitigations/session_exp.py
+++ b/mitigations/session_exp.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timedelta
+
+def generate_token_hardened(user_id, username, is_admin):
+    return {
+        'user_id': user_id,
+        'username': username,
+        'is_admin': is_admin,
+        'iat': datetime.utcnow(),
+        'exp': datetime.utcnow() + timedelta(minutes=15)
+    }
+
+#def verify_token_hardened():
+#    return jwt.decode(token, JWT_SECRET, algorithms=ALGORITHMS, options={"verify_exp": True})

--- a/mitigations/session_exp.py
+++ b/mitigations/session_exp.py
@@ -7,5 +7,5 @@ def generate_token_hardened(user_id, username, is_admin):
         'username': username,
         'is_admin': is_admin,
         'iat': datetime.utcnow(),
-        'exp': datetime.utcnow() + timedelta(minutes=1)
+        'exp': datetime.utcnow() + timedelta(seconds=5)
     }


### PR DESCRIPTION
Tokens now expire. The current time is set for 15 mins. For testing, you may want to go into session_exp.py and change it to one or two mins instead. 

Testing instructions. 
Login as any user. 

Toggle Off:
Right click and go to inspect. Go to Console tab. Paste in:
localStorage.getItem('jwt_token');
This will list the token. 
Then paste in:
fetch("/api/bill-payments/history", {
  headers: {
    "Authorization": "Bearer YOUR_TOKEN_HERE"
  }
})
.then(r => r.json()).then(console.log)

Wait for the session time to expire (15min or less if you change it in the code), then type paste in:
localStorage.getItem('jwt_token');
This will list the token. 
Then paste in:
fetch("/api/bill-payments/history", {
  headers: {
    "Authorization": "Bearer YOUR_TOKEN_HERE"
  }
})
.then(r => r.json()).then(console.log)

Result:
<img width="840" height="529" alt="Screenshot from 2026-01-27 04-31-30" src="https://github.com/user-attachments/assets/d8dc224f-fb39-4e78-9016-ebfc391b7394" />

Toggle On:
Follow the same directions as above.

Result:
<img width="841" height="555" alt="Screenshot from 2026-01-27 04-27-17" src="https://github.com/user-attachments/assets/b8a8a984-0819-4ebe-bb85-3b4410598658" />
