### PR TITLE
Login helpers for testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 from app import app as flask_app
 from database import init_connection_pool, init_db
 import app as app_module
+from helper import toggle_harden
 
 
 @pytest.fixture
@@ -17,6 +18,96 @@ def client():
     # Creates Flask test client
     with flask_app.test_client() as client:
         yield client
+
+
+def _login(client, username, password, hardened):
+    """
+    Internal helper that toggles harden state, logs in, and attaches
+    the JWT token to the client's Authorization header.
+    """
+    toggle_harden(hardened)
+
+    res = client.post("/login", json={
+        "username": username,
+        "password": password
+    })
+
+    assert res.status_code == 200, (
+        f"Login failed for '{username}' (hardened={hardened}): "
+        f"{res.status_code} {res.get_json()}"
+    )
+
+    token = res.get_json().get("token")
+    client.environ_base["HTTP_AUTHORIZATION"] = f"Bearer {token}"
+
+    return client
+
+
+@pytest.fixture
+def admin_client(client, setup_test_db):
+    """
+    Logged in as admin in vulnerable (unhardened) mode.
+
+    Usage:
+        def test_something(admin_client):
+            res = admin_client.post("/admin/create_admin", json={...})
+    """
+    return _login(
+        client,
+        username="admin",
+        password="admin123",
+        hardened=False
+    )
+
+
+@pytest.fixture
+def hardened_admin_client(client, setup_test_db):
+    """
+    Logged in as admin in hardened mode.
+
+    Usage:
+        def test_something(hardened_admin_client):
+            res = hardened_admin_client.post("/admin/create_admin", json={...})
+    """
+    return _login(
+        client,
+        username="admin",
+        password="admin123",
+        hardened=True
+    )
+
+
+@pytest.fixture
+def user_client(client, setup_test_db):
+    """
+    Logged in as a non-admin user (testuser1) in vulnerable (unhardened) mode.
+
+    Usage:
+        def test_something(user_client):
+            res = user_client.get("/some/route")
+    """
+    return _login(
+        client, username="testuser1",
+        password="testpassword1",
+        hardened=False
+    )
+
+
+@pytest.fixture
+def hardened_user_client(client, setup_test_db):
+    """
+    Logged in as a non-admin user (testuser1) in hardened mode.
+
+    Usage:
+        def test_something(hardened_user_client):
+            res = hardened_user_client.get("/some/route")
+    """
+    return _login(
+        client,
+        username="testuser1",
+        password="testpassword1",
+        hardened=True
+    )
 
 
 # Create test database
@@ -120,3 +211,24 @@ def setup_test_db():
     yield
 
     app_module.harden = False
+
+
+@pytest.fixture
+def user_exists():
+    """
+    Helper function to tests if user exists
+    This is to help with testing SQL injections
+    """
+    def _user_exists(username):
+        conn = psycopg2.connect(os.getenv("TEST_DATABASE_URL"))
+        cur = conn.cursor()
+
+        cur.execute("SELECT 1 FROM users WHERE username = %s;", (username,))
+        exists = cur.fetchone() is not None
+
+        cur.close()
+        conn.close()
+
+        return exists
+
+    return _user_exists

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,6 +315,7 @@ def setup_virtual_cards_db():
     yield
 
 
+@pytest.fixture
 def setup_bill_payments_db():
     """
     Sets the bill payments table.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,6 +315,7 @@ def setup_virtual_cards_db():
     yield
 
 
+@pytest.fixture
 def user_exists():
     """
     Helper function to tests if user exists

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -56,3 +56,28 @@ def test_transactions_table_seeded(setup_transactions_db):
     conn.close()
 
     assert count == 3
+
+
+def test_virtual_cards_table_exists(setup_test_db):
+    """Confirms the virtual_cards table exists in the test database."""
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'virtual_cards';
+    """)
+    assert cur.fetchone() is not None
+    cur.close()
+    conn.close()
+
+
+def test_virtual_cards_table_seeded(setup_virtual_cards_db):
+    """Confirms setup_virtual_cards_db inserts the expected test cards."""
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM virtual_cards;")
+    count = cur.fetchone()[0]
+    cur.close()
+    conn.close()
+
+    assert count == 2


### PR DESCRIPTION
Adds helper functions for logging in as either a regular user or admin in either hardened or vulnerable modes. Also checks that a user exists (needed for some SQLi tests). 

There might be a better way to test this, but this is what I came up with. The only way to test this is to use tests, but I didn't want to write tests specifically to test functionality for the helpers. But merging in the create_admin tests from SQLi works. 

**TO TEST LOCALLY:**
These are the steps I took, but you can probably vary them to match however you usually use git:

-git fetch origin
-git checkout remotes/origin/tests_login_helpers
-git checkout -b testing_helpers
-git pull origin tests_login_helpers
-git merge sql_test_createadmin

-docker-compose -f docker-compose-test.yml down -v
-docker-compose -f docker-compose-test.yml up --build
If getting errors with build, try running: docker-compose down -v --remove-orphans
Make sure you have the correct docker container name with:
-docker ps
Run:
-docker exec -it <container_name> pytest -v

Result:
<img width="1113" height="565" alt="Screenshot from 2026-02-19 13-37-54" src="https://github.com/user-attachments/assets/9e3780ad-206b-4568-aab3-e342b82fe462" />
