### PR TITLE
Added SQLi tests for forgot_password() - all versions

### DIFF
--- a/tests/test_sqli.py
+++ b/tests/test_sqli.py
@@ -109,3 +109,412 @@ def test_login_hardened_incorrect(client, setup_test_db):
 
     assert res.status_code == 401
     assert data["status"] == "error"
+
+
+# testing forgot_password()
+def test_forgot_password_vuln_inj(client, setup_test_db):
+    """
+    Tests if SQL injection allowed when vulnerable
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "' OR '1'='1"
+    }
+
+    res = client.post("/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_password_vuln_correct(client, setup_test_db):
+    """
+    Tests if a valid username is accepted in vulnerable state.
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "testuser1"
+    }
+
+    res = client.post("/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_password_vuln_incorrect(client, setup_test_db):
+    """
+    Tests if a non-existent username is rejected in vulnerable state.
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "nonexistentuser"
+    }
+
+    res = client.post("/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+
+def test_forgot_password_hardened_inj(client, setup_test_db):
+    """
+    Tests if SQL injection is blocked on forgot_password when in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "' OR '1'='1"
+    }
+
+    res = client.post("/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+
+def test_forgot_password_hardened_correct(client, setup_test_db):
+    """
+    Tests if a valid username is accepted in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "testuser1"
+    }
+
+    res = client.post("/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_password_hardened_incorrect(client, setup_test_db):
+    """
+    Tests if a non-existent username is rejected in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "nonexistentuser"
+    }
+
+    res = client.post("/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+# testing api_v1_forgot_password()
+def test_forgot_v1_password_vuln_inj(client, setup_test_db):
+    """
+    Tests if SQL injection allowed when vulnerable
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "' OR '1'='1"
+    }
+
+    res = client.post("/api/v1/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v1_password_vuln_correct(client, setup_test_db):
+    """
+    Tests if a valid username is accepted in vulnerable state.
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "testuser1"
+    }
+
+    res = client.post("/api/v1/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v1_password_vuln_incorrect(client, setup_test_db):
+    """
+    Tests if a non-existent username is rejected in vulnerable state.
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "nonexistentuser"
+    }
+
+    res = client.post("/api/v1/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+
+def test_forgot_v1_password_hardened_inj(client, setup_test_db):
+    """
+    Tests if SQL injection is blocked on forgot_password when in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "' OR '1'='1"
+    }
+
+    res = client.post("/api/v1/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+
+def test_forgot_v1_password_hardened_correct(client, setup_test_db):
+    """
+    Tests if a valid username is accepted in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "testuser1"
+    }
+
+    res = client.post("/api/v1/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v1_password_hardened_incorrect(client, setup_test_db):
+    """
+    Tests if a non-existent username is rejected in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "nonexistentuser"
+    }
+
+    res = client.post("/api/v1/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+# testing api_v2_forgot_password()
+def test_forgot_v2_password_vuln_inj(client, setup_test_db):
+    """
+    Tests if SQL injection allowed when vulnerable
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "' OR '1'='1"
+    }
+
+    res = client.post("/api/v2/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v2_password_vuln_correct(client, setup_test_db):
+    """
+    Tests if a valid username is accepted in vulnerable state.
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "testuser1"
+    }
+
+    res = client.post("/api/v2/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v2_password_vuln_incorrect(client, setup_test_db):
+    """
+    Tests if a non-existent username is rejected in vulnerable state.
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "nonexistentuser"
+    }
+
+    res = client.post("/api/v2/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+
+def test_forgot_v2_password_hardened_inj(client, setup_test_db):
+    """
+    Tests if SQL injection is blocked on forgot_password when in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "' OR '1'='1"
+    }
+
+    res = client.post("/api/v2/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+
+def test_forgot_v2_password_hardened_correct(client, setup_test_db):
+    """
+    Tests if a valid username is accepted in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "testuser1"
+    }
+
+    res = client.post("/api/v2/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v2_password_hardened_incorrect(client, setup_test_db):
+    """
+    Tests if a non-existent username is rejected in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "nonexistentuser"
+    }
+
+    res = client.post("/api/v2/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+# testing api_v3_forgot_password()
+def test_forgot_v3_password_vuln_inj(client, setup_test_db):
+    """
+    Tests if SQL injection allowed when vulnerable
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "' OR '1'='1"
+    }
+
+    res = client.post("/api/v3/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v3_password_vuln_correct(client, setup_test_db):
+    """
+    Tests if a valid username is accepted in vulnerable state.
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "testuser1"
+    }
+
+    res = client.post("/api/v3/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v3_password_vuln_incorrect(client, setup_test_db):
+    """
+    Tests if a non-existent username is rejected in vulnerable state.
+    """
+    toggle_harden(False)
+
+    payload = {
+        "username": "nonexistentuser"
+    }
+
+    res = client.post("/api/v3/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+
+def test_forgot_v3_password_hardened_inj(client, setup_test_db):
+    """
+    Tests if SQL injection is blocked on forgot_password when in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "' OR '1'='1"
+    }
+
+    res = client.post("/api/v3/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"
+
+
+def test_forgot_v3_password_hardened_correct(client, setup_test_db):
+    """
+    Tests if a valid username is accepted in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "testuser1"
+    }
+
+    res = client.post("/api/v3/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_forgot_v3_password_hardened_incorrect(client, setup_test_db):
+    """
+    Tests if a non-existent username is rejected in hardened state.
+    """
+    toggle_harden(True)
+
+    payload = {
+        "username": "nonexistentuser"
+    }
+
+    res = client.post("/api/v3/forgot-password", json=payload)
+    data = res.get_json()
+
+    assert res.status_code == 404
+    assert data["status"] == "error"

--- a/tests/test_sqli.py
+++ b/tests/test_sqli.py
@@ -165,7 +165,8 @@ def test_forgot_password_vuln_incorrect(client, setup_test_db):
 
 def test_forgot_password_hardened_inj(client, setup_test_db):
     """
-    Tests if SQL injection is blocked on forgot_password when in hardened state.
+    Tests if SQL injection is blocked on forgot_password
+    when in hardened state.
     """
     toggle_harden(True)
 
@@ -212,6 +213,7 @@ def test_forgot_password_hardened_incorrect(client, setup_test_db):
 
     assert res.status_code == 404
     assert data["status"] == "error"
+
 
 # testing api_v1_forgot_password()
 def test_forgot_v1_password_vuln_inj(client, setup_test_db):
@@ -267,7 +269,8 @@ def test_forgot_v1_password_vuln_incorrect(client, setup_test_db):
 
 def test_forgot_v1_password_hardened_inj(client, setup_test_db):
     """
-    Tests if SQL injection is blocked on forgot_password when in hardened state.
+    Tests if SQL injection is blocked on forgot_password
+    when in hardened state.
     """
     toggle_harden(True)
 
@@ -314,6 +317,7 @@ def test_forgot_v1_password_hardened_incorrect(client, setup_test_db):
 
     assert res.status_code == 404
     assert data["status"] == "error"
+
 
 # testing api_v2_forgot_password()
 def test_forgot_v2_password_vuln_inj(client, setup_test_db):
@@ -369,7 +373,8 @@ def test_forgot_v2_password_vuln_incorrect(client, setup_test_db):
 
 def test_forgot_v2_password_hardened_inj(client, setup_test_db):
     """
-    Tests if SQL injection is blocked on forgot_password when in hardened state.
+    Tests if SQL injection is blocked on forgot_password
+    when in hardened state.
     """
     toggle_harden(True)
 
@@ -416,6 +421,7 @@ def test_forgot_v2_password_hardened_incorrect(client, setup_test_db):
 
     assert res.status_code == 404
     assert data["status"] == "error"
+
 
 # testing api_v3_forgot_password()
 def test_forgot_v3_password_vuln_inj(client, setup_test_db):
@@ -471,7 +477,8 @@ def test_forgot_v3_password_vuln_incorrect(client, setup_test_db):
 
 def test_forgot_v3_password_hardened_inj(client, setup_test_db):
     """
-    Tests if SQL injection is blocked on forgot_password when in hardened state.
+    Tests if SQL injection is blocked on forgot_password
+    when in hardened state.
     """
     toggle_harden(True)
 


### PR DESCRIPTION
These are tests for 4 functions. The only reason that I did this as one PR is that the functions are nearly identical so the tests are the exact same for each function except for the route. 

Will request reviews once testing database stuff all merged. 

**TESTING LOCALLY :**
Run:
-docker-compose -f docker-compose-test.yml down -v
-docker-compose -f docker-compose-test.yml up --build
If getting errors with build, try running: docker-compose down -v --remove-orphans
Make sure you have the correct docker container name with:
-docker ps
Run:
-docker exec -it <container_name> pytest -v

<img width="1096" height="767" alt="Screenshot from 2026-02-18 17-12-08" src="https://github.com/user-attachments/assets/42f3dafd-2d07-4b43-9581-a3032689d569" />
