### PR TITLE
Login allowed with hashed passwords

### DIFF
--- a/app.py
+++ b/app.py
@@ -525,7 +525,14 @@ def login():
             
             print(f"Login attempt - Username: {username}")  # Debug print
 
-            if harden:
+            if app.config.get("HASHMODE", 0) != 0:
+                user_row = hashing.hashed_login(username, password)
+                user = [user_row] if user_row else []
+                #if user_row:
+                #    user = [user_row]    # wrap the single row in a list
+                #else:
+                #    user = []            # empty list = no user found
+            elif harden:
                 # Fixes SQL injection vulnerability
                 query = sql_injections.login_hardened()
                 print(f"Debug - Login query: {query}")  # Debug print

--- a/app.py
+++ b/app.py
@@ -525,8 +525,10 @@ def login():
             
             print(f"Login attempt - Username: {username}")  # Debug print
 
-            if app.config.get("HASHMODE", 0) != 0:
+            if app.config.get("HASHMODE", 0) in (1, 2, 3, 4):
+                # Returns user information from database
                 user_row = hashing.hashed_login(username, password)
+                # user_row will be returned if valid password/username
                 user = [user_row] if user_row else []
             elif harden:
                 # Fixes SQL injection vulnerability

--- a/app.py
+++ b/app.py
@@ -528,10 +528,6 @@ def login():
             if app.config.get("HASHMODE", 0) != 0:
                 user_row = hashing.hashed_login(username, password)
                 user = [user_row] if user_row else []
-                #if user_row:
-                #    user = [user_row]    # wrap the single row in a list
-                #else:
-                #    user = []            # empty list = no user found
             elif harden:
                 # Fixes SQL injection vulnerability
                 query = sql_injections.login_hardened()

--- a/auth.py
+++ b/auth.py
@@ -164,9 +164,7 @@ def init_auth_routes(app):
         conn = sqlite3.connect('bank.db')
         c = conn.cursor()
         # if passwords are not in plaintext
-        if current_app.config.get("HASHMODE", 0) != 0:
-            #hashing_login.hashed_login()
-            #hashing.hashed_login()
+        if current_app.config.get("HASHMODE", 0) in (1, 2, 3):
             user = hashing.hashed_login(auth.get('username'), auth.get('password'))
         else:
             query = f"SELECT * FROM users WHERE username='{auth.get('username')}' AND password='{auth.get('password')}'"

--- a/auth.py
+++ b/auth.py
@@ -4,6 +4,7 @@ import datetime
 import sqlite3  
 from functools import wraps
 from mitigations import session_exp
+from mitigations import hashing
 
 # Vulnerable JWT implementation with common security issues
 
@@ -164,7 +165,9 @@ def init_auth_routes(app):
         c = conn.cursor()
         # if passwords are not in plaintext
         if current_app.config.get("HASHMODE", 0) != 0:
-            hashing_login.hashed_login()
+            #hashing_login.hashed_login()
+            #hashing.hashed_login()
+            user = hashing.hashed_login(auth.get('username'), auth.get('password'))
         else:
             query = f"SELECT * FROM users WHERE username='{auth.get('username')}' AND password='{auth.get('password')}'"
             c.execute(query)

--- a/auth.py
+++ b/auth.py
@@ -164,7 +164,7 @@ def init_auth_routes(app):
         conn = sqlite3.connect('bank.db')
         c = conn.cursor()
         # if passwords are not in plaintext
-        if current_app.config.get("HASHMODE", 0) in (1, 2, 3):
+        if current_app.config.get("HASHMODE", 0) in (1, 2, 3, 4):
             user = hashing.hashed_login(auth.get('username'), auth.get('password'))
         else:
             query = f"SELECT * FROM users WHERE username='{auth.get('username')}' AND password='{auth.get('password')}'"

--- a/auth.py
+++ b/auth.py
@@ -162,10 +162,14 @@ def init_auth_routes(app):
         # Vulnerability: SQL Injection still possible here
         conn = sqlite3.connect('bank.db')
         c = conn.cursor()
-        query = f"SELECT * FROM users WHERE username='{auth.get('username')}' AND password='{auth.get('password')}'"
-        c.execute(query)
-        user = c.fetchone()
-        conn.close()
+        # if passwords are not in plaintext
+        if current_app.config.get("HASHMODE", 0) != 0:
+            hashing_login.hashed_login()
+        else:
+            query = f"SELECT * FROM users WHERE username='{auth.get('username')}' AND password='{auth.get('password')}'"
+            c.execute(query)
+            user = c.fetchone()
+            conn.close()
         
         if not user:
             return jsonify({'error': 'Invalid credentials'}), 401

--- a/mitigations/hashing.py
+++ b/mitigations/hashing.py
@@ -4,7 +4,6 @@ import os
 import random
 import hashlib
 from argon2 import PasswordHasher
-from argon2.exceptions import VerifyMismatchError
 from argon2.exceptions import VerifyMismatchError, InvalidHashError
 from flask import current_app
 
@@ -159,16 +158,13 @@ def create_hashed_password(password):
         return f"plaintext${password}"
     elif mode == 1:
         # SHA-1 Weak Hashing without salt
-        #return hashlib.sha1(password.encode()).hexdigest()
         return f"sha1${hashlib.sha1(password.encode()).hexdigest()}"
     elif mode == 2:
         # SHA-256 Medium Hashing without salt
-        #return hashlib.sha256(password.encode()).hexdigest()
         return f"sha256${hashlib.sha256(password.encode()).hexdigest()}"
     elif mode == 3:
         # Argon2id Strong Hashing, automatically salts
 
-        #return ph.hash(password)
         ph = PasswordHasher()
         return f"argon2id${ph.hash(password)}"
     elif mode == 4:
@@ -181,41 +177,34 @@ def password_options(password):
     """
     For the various toggle option
     """
-    #sel = random.choice([0, 1, 2, 3])
     sel = random.choice([1, 2, 3])
 
-    #if sel == 0:
-    #    return password
     if sel == 1:
         # SHA-1 Weak Hashing without salt
-        #return hashlib.sha1(password.encode()).hexdigest()
         return f"sha1${hashlib.sha1(password.encode()).hexdigest()}"
     elif sel == 2:
         # SHA-256 Medium Hashing without salt
-        #return hashlib.sha256(password.encode()).hexdigest()
         return f"sha256${hashlib.sha256(password.encode()).hexdigest()}"
     elif sel == 3:
         # Argon2id Strong Hashing, automatically salts
         ph = PasswordHasher()
-        #return ph.hash(password)
         return f"argon2id${ph.hash(password)}"
 
     return password
 
+
 def hashed_login(username, password):
     conn, cur = get_database()
-    #c.execute("SELECT * FROM users WHERE username = ?", (auth.get('username'),))
     cur.execute("SELECT * FROM users WHERE username = %s", (username,))
     user = cur.fetchone()
     cur.close()
     conn.close()
 
     # user[2] is the password column in the database
-    #if not user or not check_password(user[2], auth.get('password')):
-    #    return jsonify({'error': 'Invalid credentials'}), 401
     if not user or not check_password(user[2], password):
         return None
     return user
+
 
 def check_password(stored_password, submitted_password):
     hash_algo, pword = stored_password.split("$", 1)
@@ -236,4 +225,3 @@ def check_password(stored_password, submitted_password):
             return False
 
     return False
-

--- a/mitigations/hashing.py
+++ b/mitigations/hashing.py
@@ -4,6 +4,8 @@ import os
 import random
 import hashlib
 from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+from argon2.exceptions import VerifyMismatchError, InvalidHashError
 from flask import current_app
 
 
@@ -154,17 +156,20 @@ def create_hashed_password(password):
     mode = current_app.config.get("HASHMODE", 0)
 
     if mode == 0:
-        return password
+        return f"plaintext${password}"
     elif mode == 1:
         # SHA-1 Weak Hashing without salt
-        return hashlib.sha1(password.encode()).hexdigest()
+        #return hashlib.sha1(password.encode()).hexdigest()
+        return f"sha1${hashlib.sha1(password.encode()).hexdigest()}"
     elif mode == 2:
         # SHA-256 Medium Hashing without salt
-        return hashlib.sha256(password.encode()).hexdigest()
+        #return hashlib.sha256(password.encode()).hexdigest()
+        return f"sha256${hashlib.sha256(password.encode()).hexdigest()}"
     elif mode == 3:
         # Argon2id Strong Hashing, automatically salts
-        ph = PasswordHasher()
-        return ph.hash(password)
+
+        #return ph.hash(password)
+        return f"argon2id${ph.hash(password)}"
     elif mode == 4:
         return password_options(password)
 
@@ -175,19 +180,59 @@ def password_options(password):
     """
     For the various toggle option
     """
-    sel = random.choice([0, 1, 2, 3])
+    #sel = random.choice([0, 1, 2, 3])
+    sel = random.choice([1, 2, 3])
 
-    if sel == 0:
-        return password
-    elif sel == 1:
+    #if sel == 0:
+    #    return password
+    if sel == 1:
         # SHA-1 Weak Hashing without salt
-        return hashlib.sha1(password.encode()).hexdigest()
+        #return hashlib.sha1(password.encode()).hexdigest()
+        return f"sha1${hashlib.sha1(password.encode()).hexdigest()}"
     elif sel == 2:
         # SHA-256 Medium Hashing without salt
-        return hashlib.sha256(password.encode()).hexdigest()
+        #return hashlib.sha256(password.encode()).hexdigest()
+        return f"sha256${hashlib.sha256(password.encode()).hexdigest()}"
     elif sel == 3:
         # Argon2id Strong Hashing, automatically salts
         ph = PasswordHasher()
-        return ph.hash(password)
+        #return ph.hash(password)
+        return f"argon2id${ph.hash(password)}"
 
     return password
+
+def hashed_login(username, password):
+    conn, cur = get_database()
+    #c.execute("SELECT * FROM users WHERE username = ?", (auth.get('username'),))
+    cur.execute("SELECT * FROM users WHERE username = %s", (username,))
+    user = cur.fetchone()
+    cur.close()
+    conn.close()
+
+    # user[2] is the password column in the database
+    #if not user or not check_password(user[2], auth.get('password')):
+    #    return jsonify({'error': 'Invalid credentials'}), 401
+    if not user or not check_password(user[2], password):
+        return None
+    return user
+
+def check_password(stored_password, submitted_password):
+    hash_algo, pword = stored_password.split("$", 1)
+
+    if hash_algo == "plaintext":
+        return pword == submitted_password
+    elif hash_algo == "sha1":
+        return pword == hashlib.sha1(submitted_password.encode()).hexdigest()
+    elif hash_algo == "sha256":
+        return pword == hashlib.sha256(submitted_password.encode()).hexdigest()
+    elif hash_algo == "argon2id":
+        try:
+            ph = PasswordHasher()
+            return ph.verify(pword, submitted_password)
+        except VerifyMismatchError:
+            return False
+        except InvalidHashError:
+            return False
+
+    return False
+

--- a/mitigations/hashing.py
+++ b/mitigations/hashing.py
@@ -150,6 +150,7 @@ def create_hashing_db():
 def create_hashed_password(password):
     """
     Hashes the passwords according to HASHMODE
+    Encodes the hashing algorithm into the string
     """
 
     mode = current_app.config.get("HASHMODE", 0)
@@ -176,6 +177,7 @@ def create_hashed_password(password):
 def password_options(password):
     """
     For the various toggle option
+    Encodes the hashing algorithm into the string
     """
     sel = random.choice([1, 2, 3])
 
@@ -194,6 +196,10 @@ def password_options(password):
 
 
 def hashed_login(username, password):
+    """
+    Checks if the username and password match
+    information in the Users table
+    """
     conn, cur = get_database()
     cur.execute("SELECT * FROM users WHERE username = %s", (username,))
     user = cur.fetchone()
@@ -207,6 +213,10 @@ def hashed_login(username, password):
 
 
 def check_password(stored_password, submitted_password):
+    """
+    Splits the encoded hashing algorithm from the password
+    Compares input password with password in the database
+    """
     hash_algo, pword = stored_password.split("$", 1)
 
     if hash_algo == "plaintext":

--- a/mitigations/hashing.py
+++ b/mitigations/hashing.py
@@ -169,6 +169,7 @@ def create_hashed_password(password):
         # Argon2id Strong Hashing, automatically salts
 
         #return ph.hash(password)
+        ph = PasswordHasher()
         return f"argon2id${ph.hash(password)}"
     elif mode == 4:
         return password_options(password)

--- a/mitigations/hashing.py
+++ b/mitigations/hashing.py
@@ -155,9 +155,9 @@ def create_hashed_password(password):
 
     mode = current_app.config.get("HASHMODE", 0)
 
-    if mode == 0:
-        return f"plaintext${password}"
-    elif mode == 1:
+    #if mode == 0:
+    #    return password
+    if mode == 1:
         # SHA-1 Weak Hashing without salt
         return f"sha1${hashlib.sha1(password.encode()).hexdigest()}"
     elif mode == 2:
@@ -219,9 +219,9 @@ def check_password(stored_password, submitted_password):
     """
     hash_algo, pword = stored_password.split("$", 1)
 
-    if hash_algo == "plaintext":
-        return pword == submitted_password
-    elif hash_algo == "sha1":
+    #if hash_algo == "plaintext":
+    #    return pword == submitted_password
+    if hash_algo == "sha1":
         return pword == hashlib.sha1(submitted_password.encode()).hexdigest()
     elif hash_algo == "sha256":
         return pword == hashlib.sha256(submitted_password.encode()).hexdigest()

--- a/mitigations/hashing.py
+++ b/mitigations/hashing.py
@@ -155,8 +155,6 @@ def create_hashed_password(password):
 
     mode = current_app.config.get("HASHMODE", 0)
 
-    #if mode == 0:
-    #    return password
     if mode == 1:
         # SHA-1 Weak Hashing without salt
         return f"sha1${hashlib.sha1(password.encode()).hexdigest()}"
@@ -217,10 +215,11 @@ def check_password(stored_password, submitted_password):
     Splits the encoded hashing algorithm from the password
     Compares input password with password in the database
     """
+    if "$" not in stored_password:
+        return False
+
     hash_algo, pword = stored_password.split("$", 1)
 
-    #if hash_algo == "plaintext":
-    #    return pword == submitted_password
     if hash_algo == "sha1":
         return pword == hashlib.sha1(submitted_password.encode()).hexdigest()
     elif hash_algo == "sha256":


### PR DESCRIPTION
This is the first of several PRs related to the hashing passwords stretch goal. This one needs to be merged first. I won't request reviewers for the others until they are ready and I will leave them as drafts. 

This PR allows the user to login no matter what mode the hashing toggle is in (previously the app could only handle plaintext passwords). 

To Test:
docker-compose down -v
docker-compose up --build

Try logging in as an existing user such as: username: admin, password: admin123
Repeat this for each hashing toggle mode (None, Weak, Medium, Strong, Various, None again)
You should be able to login successfully in each mode. 

Note: If you want to see other users and their passwords, toggle to None and run this in the browser console:
fetch('/api/hashed-passwords') .then(r=>r.json()) .then(d=>console.log(d))

You can try to login as any of those users. 

FYI - registering new users will not work correctly in this version (that is addressed in another PR that I will make shortly). 
You can register new users in the None hashing mode and log in as them in the None hashing mode. 
You cannot register new users if the hashing mode is anything other than None. 
If you register a new user in the None mode and then change the toggle to another mode - you will not be able to log in as the new user. 