### PR TITLE
Seed DB on Startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from mitigations import session_exp
 from mitigations import SSRF
 from mitigations import rate_limiting
 from mitigations import hashing
+from pathlib import Path
 
 
 # Load environment variables
@@ -33,6 +34,28 @@ load_dotenv()
 
 # Initialize Flask app
 app = Flask(__name__)
+
+def seed_database_on_startup():
+    """
+    Seed database once on app startup if seed users don't exist.
+    """
+    try:
+        from database import get_connection
+        conn = get_connection()
+        with conn.cursor() as cur:
+            # Check if seed users already exist
+            cur.execute("SELECT COUNT(*) FROM users WHERE username IN ('testuser1', 'testuser2', 'testuser3');")
+            if cur.fetchone()[0] > 0:
+                return
+            
+            # Load and execute seed SQL
+            seed_file = Path(__file__).parent / "seed_data.sql"
+            if seed_file.exists():
+                with open(seed_file, "r", encoding="utf-8") as f:
+                    cur.execute(f.read())
+                conn.commit()
+    except Exception as e:
+        print(f"[startup] Seed failed: {e}")
 
 # Initialize database connection pool
 #init_connection_pool()
@@ -2807,6 +2830,8 @@ if __name__ == '__main__':
     if os.getenv("APP_ENV") != "test":
         init_db()
     init_auth_routes(app)
+
+    seed_database_on_startup()
 
     # Debug mode toggle
     if harden:

--- a/seed_data.sql
+++ b/seed_data.sql
@@ -1,0 +1,29 @@
+-- Seed data for vulnerable_bank database
+-- Non-destructive: only runs if tables are empty
+
+INSERT INTO users (id, username, password, account_number, balance, is_admin)
+VALUES
+  (1, 'admin', 'admin123', 'ADMIN001', 1000000.00, TRUE),
+  (100, 'testuser1', 'testpassword1', 'TEST001', 1000.00, FALSE),
+  (101, 'testuser2', 'testpassword2', 'TEST002', 1000.00, FALSE),
+  (102, 'testuser3', 'testpassword3', 'TEST003', 1000.00, FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO transactions (from_account, to_account, amount, transaction_type, description)
+VALUES
+  ('TEST001', 'TEST002', 100.00, 'transfer', 'Test transfer 1'),
+  ('TEST002', 'TEST001', 50.00, 'transfer', 'Test transfer 2'),
+  ('TEST001', 'TEST003', 25.00, 'transfer', 'Test transfer 3')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO virtual_cards (user_id, card_number, cvv, expiry_date, card_limit, current_balance, card_type, is_frozen)
+VALUES
+  (100, '1111222233334444', '123', '12/26', 1000.00, 1000.00, 'standard', FALSE),
+  (101, '5555666677778888', '456', '12/26', 1000.00, 1000.00, 'standard', FALSE)
+ON CONFLICT (card_number) DO NOTHING;
+
+INSERT INTO bill_payments (user_id, biller_id, amount, payment_method, card_id, reference_number, status, description)
+VALUES
+  (100, 1, 75.00, 'balance', NULL, 'REF001', 'completed', 'Water bill payment'),
+  (100, 2, 120.00, 'virtual_card', 1, 'REF002', 'completed', 'Electric bill payment')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Copied the seed commands in conftest.py out to a separate file as standard SQL statements and added logic to app.py to make those commands run on startup. Currently separate from the test yaml and workflow, so none of that is affected. Presence of testusers and transactions can be verified manually or by executing the following commands in CLI while the app is running:
```
docker-compose exec db psql -U postgres -d vulnerable_bank -c "select id, username from users order by id;"
docker-compose exec db psql -U postgres -d vulnerable_bank -c "select count(*) from transactions;"
docker-compose exec db psql -U postgres -d vulnerable_bank -c "select count(*) from virtual_cards;"
docker-compose exec db psql -U postgres -d vulnerable_bank -c "select count(*) from bill_payments;"
```